### PR TITLE
 디자인 수정 및 메뉴 포커스  개선

### DIFF
--- a/src/app/(route)/(community)/_components/LeftSidebar.tsx
+++ b/src/app/(route)/(community)/_components/LeftSidebar.tsx
@@ -1,14 +1,15 @@
 "use client";
-import { usePathname } from "next/navigation";
-import { useRouter } from "next/navigation";
+
+import { usePathname, useRouter } from "next/navigation";
 
 const LeftSidebar = () => {
   const router = useRouter();
   const pathname = usePathname();
-  const pathParts = pathname.split("/");
 
+  const pathParts = pathname.split("/");
   const rootPath = pathParts[1];
-  const boardType = pathname.split("/")[2];
+  const boardType = pathParts[2];
+  const activeTab = pathParts[3]?.toUpperCase();
 
   const boardList = [
     { name: "전체", id: "ALL", path: `/${rootPath}/${boardType}/ALL` },
@@ -43,19 +44,21 @@ const LeftSidebar = () => {
   return (
     <div className="w-[160px] h-[364px]">
       <div className="w-full bg-white rounded-[5px]">
-        {boardList.map((board) => (
-          <div
-            onClick={() => board.path && handleRoute(board.path)}
-            key={board.id}
-            className={`w-full h-[52px] px-[16px] py-[12px] flex justify-start items-center  cursor-pointer hover:text-gra ${
-              board.id && pathname.includes(board.id)
-                ? "font-[700] text-gra"
-                : "font-[400] text-gray7"
-            }`}
-          >
-            <p>{board.name}</p>
-          </div>
-        ))}
+        {boardList.map((board) => {
+          const isActive = board.id === activeTab;
+
+          return (
+            <div
+              key={board.id}
+              onClick={() => handleRoute(board.path)}
+              className={`w-full h-[52px] px-[16px] py-[12px] flex justify-start items-center cursor-pointer hover:text-gra ${
+                isActive ? "font-[700] text-gra" : "font-[400] text-gray7"
+              }`}
+            >
+              <p>{board.name}</p>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/app/(route)/(community)/_components/PostAction.tsx
+++ b/src/app/(route)/(community)/_components/PostAction.tsx
@@ -64,21 +64,17 @@ const PostAction = ({ type, onReport, source }: PostActionProps) => {
       <div className="max-w-[237px] min-h-[35px] flex gap-2">
         <button
           onClick={copyBtn}
-          className="min-w-[138px] w-auto h-[32px] flex justify-center items-center bg-white px-3 py-2 rounded-[5px] border border-gray3 text-[14px] leading-[14px] font-medium"
+          className="min-w-[138px] w-auto h-[32px] flex justify-center items-center bg-white px-2 pr-3 pl-[10px] gap-1 rounded-[5px] border border-gray3 text-[14px] leading-[14px] font-medium whitespace-nowrap"
         >
-          <span className="w-[96px] h-[14px] font-medium text-[14px] ">
-            <Copy />
-            게시글 URL 복사
-          </span>
+          <Copy />
+          게시글 URL 복사
         </button>
         <button
           onClick={modalPopUp}
           className="min-w-[91px] w-auto h-[32px] flex justify-center items-center bg-white pr-[12px] pl-[10px] py-2 rounded-[5px] border border-gray3 text-[14px] leading-[14px] text-nowrap font-medium"
         >
           <Share />
-          <span className="w-[49px] h-[14px] font-medium text-[14px]">
-            공유하기
-          </span>
+          공유하기
         </button>
       </div>
       {activeModal && (

--- a/src/app/(route)/(community)/_components/PostItem.tsx
+++ b/src/app/(route)/(community)/_components/PostItem.tsx
@@ -92,7 +92,7 @@ const PostItem = ({ boardType, categoryType, boardData }: PostItemProps) => {
             <span>{numberOverThousand(data?.id)}</span>
           </div>
           <div className="flex items-center gap-[10px]">
-            <div className="w-[56px] h-[42px] relative box-content">
+            <div className=" w-[56px] h-[42px] relative box-content">
               {data?.thumbnail ? (
                 <Image
                   src={data.thumbnail}

--- a/src/app/(route)/(community)/_components/PostItem.tsx
+++ b/src/app/(route)/(community)/_components/PostItem.tsx
@@ -86,7 +86,7 @@ const PostItem = ({ boardType, categoryType, boardData }: PostItemProps) => {
           href={`/board/${boardType}/${data.categoryType}/${data.id}`}
           key={`${data.id}-${index}`}
           onClick={() => handlePostClick(data.id)}
-          className={`flex items-center w-[720px] min-h-[66px] gap-[12px] border-b p-[12px] `}
+          className={`flex items-center w-[720px] min-h-[66px] gap-[12px] border-b p-[12px]`}
         >
           <div className="flex items-center justify-center w-[32px] h-[32px] rounded-[2px] p-2 bg-gray1">
             <span>{numberOverThousand(data?.id)}</span>

--- a/src/app/(route)/(community)/_components/PostItem.tsx
+++ b/src/app/(route)/(community)/_components/PostItem.tsx
@@ -86,7 +86,7 @@ const PostItem = ({ boardType, categoryType, boardData }: PostItemProps) => {
           href={`/board/${boardType}/${data.categoryType}/${data.id}`}
           key={`${data.id}-${index}`}
           onClick={() => handlePostClick(data.id)}
-          className={`flex items-center w-[720px] min-h-[66px] gap-[12px] border-b p-[12px]`}
+          className={`flex items-center w-[720px] min-h-[66px] gap-[12px] border-b p-[12px] `}
         >
           <div className="flex items-center justify-center w-[32px] h-[32px] rounded-[2px] p-2 bg-gray1">
             <span>{numberOverThousand(data?.id)}</span>
@@ -109,9 +109,9 @@ const PostItem = ({ boardType, categoryType, boardData }: PostItemProps) => {
             </div>
           </div>
           <div className="flex flex-col justify-center flex-1 gap-y-[4px]">
-            <div className="flex items-center gap-[2px]">
+            <div className="flex items-center gap-[2px] max-w-[584px]">
               <h2
-                className={`text-[14px] leading-[20px] overflow-hidden whitespace-nowrap overflow-ellipsis ${
+                className={`text-[14px] leading-[20px] overflow-hidden whitespace-nowrap overflow-ellipsis  ${
                   isPostRead(data?.id) ? "text-gray5" : "text-gray7"
                 }`}
               >
@@ -128,7 +128,7 @@ const PostItem = ({ boardType, categoryType, boardData }: PostItemProps) => {
               </span>
             </div>
             <div className="flex font-semibold gap-1 items-center">
-              <p className="text-[12px] leading-[18px] text-gray5">
+              <p className="text-[12px] leading-[18px] text-gray5 ">
                 {getKoreanBoardType(data?.boardType)}
               </p>
               <span className="font-medium text-[12px] leading-[18px] text-gray5">

--- a/src/app/(route)/(community)/_components/RightNewsItem.tsx
+++ b/src/app/(route)/(community)/_components/RightNewsItem.tsx
@@ -46,7 +46,7 @@ const RightNewsItem = ({ newsItem, customClass }: NewsItemProps) => {
         onClick={handleRead}
         className={`min-w-[288px] min-h-[92px] flex justify-center items-center border-b border-gray2 p-3 cursor-pointer gap-3  ${customClass}`}
       >
-        <div className=" w-[68px] h-[68px]">
+        <div className="w-[68px] h-[68px]">
           {updatedImgUrl ? (
             <Image
               src={updatedImgUrl}

--- a/src/app/(route)/(community)/_components/RightNewsItem.tsx
+++ b/src/app/(route)/(community)/_components/RightNewsItem.tsx
@@ -46,7 +46,7 @@ const RightNewsItem = ({ newsItem, customClass }: NewsItemProps) => {
         onClick={handleRead}
         className={`min-w-[288px] min-h-[92px] flex justify-center items-center border-b border-gray2 p-3 cursor-pointer gap-3  ${customClass}`}
       >
-        <div className="w-[68px] h-[68px]">
+        <div className=" w-[68px] h-[68px]">
           {updatedImgUrl ? (
             <Image
               src={updatedImgUrl}

--- a/src/app/(route)/customer/_components/FeedbackItem.tsx
+++ b/src/app/(route)/customer/_components/FeedbackItem.tsx
@@ -74,7 +74,7 @@ const FeedbackItem = ({
             src={feedbackData.thumbnail}
             alt="post-preview-image"
             fill
-            className="object-cover rounded-[5px]"
+            className="object-contain rounded-[5px]"
           />
         ) : (
           <CustomIcon

--- a/src/app/(route)/customer/_components/FeedbackItem.tsx
+++ b/src/app/(route)/customer/_components/FeedbackItem.tsx
@@ -68,13 +68,13 @@ const FeedbackItem = ({
       <div className="w-[32px] h-[32px] rounded-[2px] p-1 flex gap-[10px] bg-gray1 items-center justify-center flex-shrink-0">
         <p className="font-bold text-[14px] leading-5">{feedbackData?.id}</p>
       </div>
-      <div className="w-[56px] h-[42px] rounded-[5px] bg-gray1 overflow-hidden  flex-shrink-0">
+      <div className="relative w-[56px] h-[42px] rounded-[5px] bg-gray1 overflow-hidden  flex-shrink-0">
         {feedbackData?.thumbnail ? (
           <Image
             src={feedbackData.thumbnail}
             alt="post-preview-image"
             fill
-            className="object-contain rounded-[5px]"
+            className="object-cover rounded-[5px]"
           />
         ) : (
           <CustomIcon

--- a/src/app/(route)/customer/_components/FeedbackItem.tsx
+++ b/src/app/(route)/customer/_components/FeedbackItem.tsx
@@ -92,7 +92,7 @@ const FeedbackItem = ({
         )}
       >
         <div className="w-full min-h-[20px] flex items-center gap-[2px]">
-          <p className="text-[14px] leading-5 text-gray7 text-ellipsis overflow-hidden line-clamp-1">
+          <p className="text-[14px] leading-5 text-gray7 text-ellipsis overflow-hidden line-clamp-1 whitespace-nowrap">
             {searchType === "TITLE" || searchType === "TITLE_CONTENT"
               ? highlightText(feedbackData?.title, searchType, searchString)
               : feedbackData?.title}

--- a/src/app/(route)/customer/_components/NoticeItem.tsx
+++ b/src/app/(route)/customer/_components/NoticeItem.tsx
@@ -73,7 +73,7 @@ const NoticeItem = ({
           {!isFeedback ? noticeData?.id : "공지"}
         </p>
       </div>
-      <div className="w-[56px] h-[42px]  rounded-[5px] overflow-hidden bg-gray1 flex-shrink-0">
+      <div className="relative w-[56px] h-[42px]  rounded-[5px] overflow-hidden bg-gray1 flex-shrink-0">
         {noticeData?.thumbnail ? (
           <Image
             src={noticeData.thumbnail}

--- a/src/app/(route)/main/_components/NewPostItem.tsx
+++ b/src/app/(route)/main/_components/NewPostItem.tsx
@@ -20,7 +20,7 @@ const NewPostItem = ({ newPosts }: NewPostItemProps) => {
             {numberOverThousand(newPosts?.id ?? 0)}
           </p>
         </div>
-        <div className="max-w-[40px] min-h-[18px] font-[700] text-[12px] leading-[18px] text-gray5 tracking-[-0.02em] mr-[8px]">
+        <div className="max-w-[40px] min-h-[18px] font-[700] text-[12px] leading-[18px] text-gray5 tracking-[-0.02em] mr-[8px] whitespace-nowrap">
           {getKoreanBoardType(newPosts?.boardType)}
         </div>
         <div className="max-w-[300px] min-h-[20px] flex gap-[2px] items-center font-[500] text-[14px] leading-5 mr-[2px]">

--- a/src/app/(route)/main/_components/hotPostItem.tsx
+++ b/src/app/(route)/main/_components/hotPostItem.tsx
@@ -20,7 +20,7 @@ const HotPostItem = ({ number, hotPosts }: HotPostItemProps) => {
         <div className="w-[20px] h-[20px] rounded-sm gap-[10px] font-bold text-[12px] leading-[18px] text-gray7">
           {number}
         </div>
-        <div className="max-w-[40px] min-h-[18px] font-[700] text-[12px] leading-[18px] text-gray5">
+        <div className="max-w-[40px] min-h-[18px] font-[700] text-[12px] leading-[18px] text-gray5 whitespace-nowrap">
           {getKoreanBoardType(hotPosts?.boardType)}
         </div>
         <div className="flex justify-center align-center items-center text-center gap-[2px]">

--- a/src/app/_components/_gnb/Navbar.tsx
+++ b/src/app/_components/_gnb/Navbar.tsx
@@ -27,61 +27,105 @@ export default function Navbar() {
     const searchPath = `/total-search/board?search=${encodeURIComponent(
       trimmedValue
     )}`;
-
     setIsSearching(true);
     router.push(searchPath);
   };
-  const isCurrentPath = (Id: string) => {
+
+  const isCurrentPath = (id: string) => {
     if (!pathname) return false;
-    return pathname.includes(Id);
+    const lowerPath = pathname.toLowerCase();
+    const lowerId = id.toLowerCase();
+
+    const isNewsPath =
+      lowerPath.startsWith("/news") ||
+      lowerPath.startsWith("/news/football") ||
+      lowerPath.startsWith("/news/baseball");
+
+    if (isNewsPath) return lowerId === "news";
+    if (lowerPath.startsWith("/main") && lowerId === "main") return true;
+
+    const boardMatch = lowerPath.match(
+      /^\/board\/([^/]+)\/([^/]+)(?:\/(\d+))?/
+    );
+    if (boardMatch) {
+      const category = boardMatch[1];
+      const tab = boardMatch[2];
+      const postId = boardMatch[3];
+
+      if (postId) {
+        return lowerId === category || (lowerId === tab && tab !== "all");
+      }
+
+      if (tab === "all") {
+        return lowerId === "all" || lowerId === category;
+      } else {
+        return lowerId === category || lowerId === tab;
+      }
+    }
+
+    if (lowerPath.startsWith("/matchbroadcast")) {
+      return lowerId === "matchbroadcast" || lowerId === "경기중계";
+    }
+
+    return false;
   };
 
   const navbarClass =
-    "min-h-[60px] p-[16px] whitespace-nowrap font-medium text-[18px] leading-7 tracking-[-0.04em] text-center cursor-pointer";
+    "flex min-h-[60px] p-[16px] whitespace-nowrap font-medium text-[18px] leading-7 tracking-[-0.04em] text-center cursor-pointer";
 
   return (
-    <div className="w-full max-w-[1200px] min-h-[60px] flex justify-between items-center mx-auto">
-      <div className="max-w-[447px] min-h-[60px] flex justify-around gap-2.5">
-        {NAVBARS.map((item, index) => (
-          <Link key={item.id} href={item.link}>
+    <>
+      <div className="w-full max-w-[1200px] min-h-[60px] flex justify-between items-center mx-auto">
+        <div className=" max-w-[447px] min-h-[60px] flex justify-around gap-2.5">
+          {NAVBARS.map((item, index) => (
+            <Link key={item.id} href={item.link}>
+              <div
+                className={`${navbarClass} flex justify-around items-center hover:text-gra ${
+                  isCurrentPath(item.id)
+                    ? "font-normal text-gra"
+                    : "font-normal text-gray7"
+                } ${index === 0 ? "pl-0" : ""}`}
+              >
+                {item.name}
+              </div>
+            </Link>
+          ))}
+        </div>
+
+        <div className=" flex justify-end items-center mb-2 w-full">
+          <div className="w-[414px] h-[48px] rounded-full bg-white border-[0.5px] px-4 flex items-center gap-[10px] relative transition-all focus-within:ring-1 focus-within:ring-gray9 md:flex md:bg-gray1">
             <div
-              className={`${navbarClass} flex justify-around items-center hover:text-gra ${
-                isCurrentPath(item.id)
-                  ? "font-normal text-gra"
-                  : "font-normal text-gray7"
-              } ${index === 0 ? "pl-0" : ""}`}
+              className="cursor-pointer hidden md:block"
+              onClick={handleToSearch}
             >
-              {item.name}
+              <Search />
             </div>
-          </Link>
-        ))}
-      </div>
-      <div className="flex items-center mb-2">
-        <div className="w-[414px] h-[48px] rounded-full bg-gray1 border-[0.5px] px-4 flex items-center gap-[16px] relative transition-all focus-within:ring-1 focus-within:ring-gray9">
-          <div className="cursor-pointer" onClick={handleToSearch}>
-            <Search />
+
+            <input
+              className="w-full h-full bg-transparent border-none outline-none focus:outline-none focus:ring-0 focus:border-none placeholder:text-gray5"
+              placeholder="검색어를 입력해주세요"
+              value={isValue}
+              onChange={(e) => setIsValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                  handleToSearch();
+                }
+              }}
+            />
+            {isValue && (
+              <button
+                className="absolute top-3 right-4 text-gray-400 hover:text-gray-600"
+                onClick={() => setIsValue("")}
+              >
+                <CustomIcon
+                  icon="SEARCH_X_ICON"
+                  className="w-[20px] h-[20px]"
+                />
+              </button>
+            )}
           </div>
-          <input
-            className="w-full h-full bg-transparent border-none outline-none focus:outline-none focus:ring-0 focus:border-none placeholder:text-gray5"
-            placeholder="검색어를 입력해주세요"
-            value={isValue}
-            onChange={(e) => setIsValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-                handleToSearch();
-              }
-            }}
-          />
-          {isValue && (
-            <button
-              className="absolute right-4 text-gray-400 hover:text-gray-600"
-              onClick={() => setIsValue("")}
-            >
-              <CustomIcon icon="SEARCH_X_ICON" className="w-[20px] h-[20px]" />
-            </button>
-          )}
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/app/_components/_gnb/Navbar.tsx
+++ b/src/app/_components/_gnb/Navbar.tsx
@@ -71,7 +71,7 @@ export default function Navbar() {
   };
 
   const navbarClass =
-    "flex min-h-[60px] p-[16px] whitespace-nowrap font-medium text-[18px] leading-7 tracking-[-0.04em] text-center cursor-pointer";
+    "min-h-[60px] p-[16px] whitespace-nowrap font-medium text-[18px] leading-7 tracking-[-0.04em] text-center cursor-pointer";
 
   return (
     <>


### PR DESCRIPTION
## 변경 사항 요약

 디자인 수정 및 메뉴 포커스  개선

### 추가된 기능

디자인 수정 
whitespace-nowrap 추가
현재 탭 활성화 로직 추가 (activeTab)
불필요한 span 제거 
Imge에 relative 추가

메뉴 포커스 개선
게시글 상세에서도 적절한 메뉴 강조 처리
/board/:category/:tab/:postId 형태까지 인식

게시글 상세(postId 존재 시)

. 목록 페이지에서도 적절한 분기 처리
tab이 "all"일 경우엔 category와 all 둘 다 강조

이외에는 category와 tab 각각 비교하여 강조 처리

뉴스, 메인, 경기중계 페이지도 각 메뉴와 정확히 매칭되는 조건 처리



category는 항상 강조

tab이 "all"이 아닐 경우에만 tab도 강조

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [ ] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

<!-- 리뷰어가 주목해야 할 부분이나 추가적인 정보가 있다면 기재해주세요. -->

### PR 올리기 전 체크리스트 (필수로 체크)

- [ ] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [ ] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인