### PR TITLE
소셜 로그인 버그 수정(배포 테스트 필요)

### DIFF
--- a/src/_hooks/fetcher/sign/useHandleRefreshToken.ts
+++ b/src/_hooks/fetcher/sign/useHandleRefreshToken.ts
@@ -10,7 +10,11 @@ const useHandleRefreshToken = () => {
   const { mutate: reissue } = useReissue();
 
   useEffect(() => {
-    if (refreshToken) {
+    if (
+      refreshToken &&
+      !localStorage.getItem("refreshToken") &&
+      typeof window !== "undefined"
+    ) {
       localStorage.setItem("refreshToken", refreshToken);
       reissue();
     }

--- a/src/_hooks/useReissue.ts
+++ b/src/_hooks/useReissue.ts
@@ -38,10 +38,10 @@ const useReissue = () => {
       if (axios.isAxiosError(error) && error.response?.status === 401) {
         localStorage.removeItem("accessToken");
         queryClient.refetchQueries({ queryKey: ["authCheck"] });
+        logout();
         queryClient.invalidateQueries({ queryKey: ["inquiriesList"] });
         queryClient.invalidateQueries({ queryKey: ["myPostList"] });
         queryClient.invalidateQueries({ queryKey: ["myCommentList"] });
-        logout();
       }
     },
   });

--- a/src/_hooks/useReissue.ts
+++ b/src/_hooks/useReissue.ts
@@ -28,20 +28,20 @@ const useReissue = () => {
     mutationFn: handleReissue,
     retry: false,
     onSuccess: (data) => {
-      login();
       localStorage.removeItem("accessToken");
       localStorage.removeItem("refreshToken");
       localStorage.setItem("accessToken", data.headers.authorization);
       queryClient.invalidateQueries({ queryKey: ["authCheck"] });
+      login();
     },
     onError: (error) => {
       if (axios.isAxiosError(error) && error.response?.status === 401) {
-        logout();
         localStorage.removeItem("accessToken");
         queryClient.invalidateQueries({ queryKey: ["authCheck"] });
         queryClient.invalidateQueries({ queryKey: ["inquiriesList"] });
         queryClient.invalidateQueries({ queryKey: ["myPostList"] });
         queryClient.invalidateQueries({ queryKey: ["myCommentList"] });
+        logout();
       }
     },
   });

--- a/src/_hooks/useReissue.ts
+++ b/src/_hooks/useReissue.ts
@@ -31,13 +31,13 @@ const useReissue = () => {
       localStorage.removeItem("accessToken");
       localStorage.removeItem("refreshToken");
       localStorage.setItem("accessToken", data.headers.authorization);
-      queryClient.invalidateQueries({ queryKey: ["authCheck"] });
+      queryClient.refetchQueries({ queryKey: ["authCheck"] });
       login();
     },
     onError: (error) => {
       if (axios.isAxiosError(error) && error.response?.status === 401) {
         localStorage.removeItem("accessToken");
-        queryClient.invalidateQueries({ queryKey: ["authCheck"] });
+        queryClient.refetchQueries({ queryKey: ["authCheck"] });
         queryClient.invalidateQueries({ queryKey: ["inquiriesList"] });
         queryClient.invalidateQueries({ queryKey: ["myPostList"] });
         queryClient.invalidateQueries({ queryKey: ["myCommentList"] });

--- a/src/app/(route)/mypage/edit-profile/page.tsx
+++ b/src/app/(route)/mypage/edit-profile/page.tsx
@@ -203,25 +203,30 @@ const EditProfile = () => {
             <ProfileImage imageUrl={imageUrl} setImageUrl={setImageUrl} />
             <div className="flex justify-between min-h-[56px] rounded-[10px] p-[16px] bg-[#FAFAFA] text-gray8">
               <p className="leading-[24px]">가입 유형</p>
-              <p className="font-[700] leading-[24px] text-gray7">
-                {mypageData?.data?.registrationMethod === "LOCAL"
-                  ? "일반 회원가입"
-                  : `${
-                      REGISTRATION[mypageData?.data?.registrationMethod]
-                        ?.defaultText
-                    }(${
-                      REGISTRATION[mypageData?.data?.registrationMethod]?.value
-                    })`}
-              </p>
+              {mypageData?.data?.registrationMethod && (
+                <p className="font-[700] leading-[24px] text-gray7">
+                  {mypageData?.data?.registrationMethod === "LOCAL"
+                    ? "일반 회원가입"
+                    : `${
+                        REGISTRATION[mypageData?.data?.registrationMethod]
+                          ?.defaultText
+                      }(${
+                        REGISTRATION[mypageData?.data?.registrationMethod]
+                          ?.value
+                      })`}
+                </p>
+              )}
             </div>
 
             {inputObject.map((input) => (
               <div
                 key={input.id}
                 className={`flex flex-col gap-[4px] ${
+                  mypageData?.data?.registrationMethod &&
                   mypageData?.data?.registrationMethod !== "LOCAL" &&
-                  input.id === "password" &&
-                  "hidden"
+                  input.id === "password"
+                    ? "hidden"
+                    : ""
                 }`}
               >
                 <Input

--- a/src/app/(route)/mypage/layout.tsx
+++ b/src/app/(route)/mypage/layout.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@/utils";
 import MypageLeftSidebar from "./_components/MypageLeftSidebar";
-import MobileBackButton from "./_components/MobileBackButton";
 
 export const metadata = {
   title: "마이페이지",
@@ -31,12 +30,11 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       </div>
       <div
         className={cn(
-          "mt-[20px] max-w-[1200px] flex mx-auto gap-[20px]",
+          "mt-[20px] max-w-[1200px] flex mx-auto gap-[16px]",
           "tablet:flex-col tablet:items-center tablet:gap-0",
           "mobile:mt-0 mobile:flex-col mobile:gap-0"
         )}
       >
-        {/* <MobileBackButton /> */}
         <div
           className={cn(
             "w-[160px] min-h-[364px]",

--- a/src/app/(route)/mypage/page.tsx
+++ b/src/app/(route)/mypage/page.tsx
@@ -154,12 +154,15 @@ const Mypage = () => {
           <p className="text-[14px] leading-[20px] font-[400] text-[#656565]">
             회원가입일: {mypage?.registeredAt}
           </p>
-          <p className="text-[14px] leading-[20px] font-[400] text-[#656565]">
-            가입 유형 : {REGISTRATION[mypage?.registrationMethod]?.defaultText}
-            {mypage?.registrationMethod !== "LOCAL"
-              ? `, ${REGISTRATION[mypage?.registrationMethod]?.value}`
-              : "일반 회원가입"}
-          </p>
+          {mypage?.registrationMethod && (
+            <p className="text-[14px] leading-[20px] font-[400] text-[#656565]">
+              가입 유형 :{" "}
+              {REGISTRATION[mypage?.registrationMethod]?.defaultText}
+              {mypage?.registrationMethod !== "LOCAL"
+                ? `, ${REGISTRATION[mypage?.registrationMethod]?.value}`
+                : "일반 회원가입"}
+            </p>
+          )}
         </div>
       </div>
       <Link


### PR DESCRIPTION
## 변경 사항 요약

<!-- PR에서 구현된 주요 변경 사항을 간단하게 설명해주세요. -->

### 추가된 기능
1. 소셜 로그인을 성공하고 홈으로 리다이렉트 되어도, 즉시 로그인 처리가 되지 않음 새로고침을 해주어야지 로그인 처리가 됨: 리이슈 훅 성공/실패 함수에서 로직 순서 변경 처리 함
2. 소셜 로그인을 성공했을 때 리이슈가 성공됐으니 리프레쉬 토큰이 삭제되어야 하는데 삭제되지 않음: useHandleRefreshToken 훅에서 이미 로컬스토리지에 리프레쉬 토큰이 있다면 중복 저장되지 않도록 조건 추가
3. 소셜 로그인 계정으로 마이페이지 접속 시 가입 유형이 undefined로 표시됨
4. 소셜 로그인 계정으로 마이페이지 내 정보 수정에 접속 시 비밀번호 input이 사라지지 않음
3, 4번 문제 모두 유저 타입이 있을 떄 렌더링 하도록 변경

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [ ] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

<!-- 리뷰어가 주목해야 할 부분이나 추가적인 정보가 있다면 기재해주세요. -->

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
