### PR TITLE
[FEAT] 경기일정 페이지 작업

### DIFF
--- a/src/app/(route)/matchBroadcast/[matchType]/[matchId]/page.tsx
+++ b/src/app/(route)/matchBroadcast/[matchType]/[matchId]/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { use } from "react";
+import { use, useRef, useState } from "react";
 import LiveSection from "../../_components/LiveSection";
 import MatchPrediction from "../../_components/MatchPrediction";
 import useGetMatchSchedule from "@/_hooks/fetcher/match-controller/useGetMatchSchedule";
 import MatchDetailSkeleton from "../../_components/matchSkeleton";
+import BoardComment from "@/app/(route)/(community)/_components/BoardComment";
+import SendCommentBox from "@/app/_components/_comment/SendCommentBox";
+import { CommentItem } from "@/_types/comment";
 
 export default function MatchDetailPage({
   params,
@@ -14,26 +17,62 @@ export default function MatchDetailPage({
   const unwrappedParams = use(params);
   const { matchType, matchId } = unwrappedParams;
   const matchIdNum = matchId;
+  const stringId = matchId.toString();
+
+  const [parentsComment, setParentsComment] = useState<CommentItem | null>(
+    null
+  );
 
   const { data: matchSchedule, isLoading } = useGetMatchSchedule(matchType);
+
+  const comments = useRef(null);
+
+  const onHandleToTop = () => {
+    if (comments.current) {
+      const navBarHeight = 130; // 네비게이션 바 높이
+      const y =
+        comments.current.getBoundingClientRect().top +
+        window.scrollY -
+        navBarHeight;
+      window.scrollTo({ top: y, behavior: "smooth" });
+    }
+  };
 
   if (isLoading) {
     return <MatchDetailSkeleton matchType={matchType} />;
   }
 
   return (
-    <div className="flex justify-start w-full max-w-[1200px] items-center mx-auto gap-x-[40px]">
-      <div className="flex flex-col w-[800px] ">
+    <div className="flex flex-col justify-start w-full max-w-[1200px] mx-auto gap-x-[40px]">
+      <div className="flex flex-col max-w-[800px] ">
         {matchType === "ESPORTS" && (
           <div className="w-full">
             <LiveSection matchId={matchIdNum} />
           </div>
         )}
-        <div className="w-full ">
+        <div className="w-full">
           <MatchPrediction scheduleData={matchSchedule} matchId={matchIdNum} />
         </div>
       </div>
-      {/* <div className="w-[360px]">채팅 구역</div> */}
+      <div className="w-full max-w-[800px] bg-white">
+        <BoardComment
+          ref={comments}
+          id={stringId}
+          setParentsComment={setParentsComment}
+          type="MATCH"
+        />
+      </div>
+
+      <div className="sticky bottom-0 bg-white z-50 flex justify-center w-full max-w-[800px]">
+        <div className="w-full max-w-[768px]">
+          <SendCommentBox
+            id={stringId}
+            type="MATCH"
+            parentsComment={parentsComment}
+            setParentsComment={setParentsComment}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(route)/matchBroadcast/[matchType]/[matchId]/page.tsx
+++ b/src/app/(route)/matchBroadcast/[matchType]/[matchId]/page.tsx
@@ -4,6 +4,7 @@ import { use } from "react";
 import LiveSection from "../../_components/LiveSection";
 import MatchPrediction from "../../_components/MatchPrediction";
 import useGetMatchSchedule from "@/_hooks/fetcher/match-controller/useGetMatchSchedule";
+import MatchDetailSkeleton from "../../_components/matchSkeleton";
 
 export default function MatchDetailPage({
   params,
@@ -14,7 +15,11 @@ export default function MatchDetailPage({
   const { matchType, matchId } = unwrappedParams;
   const matchIdNum = matchId;
 
-  const { data: matchSchedule } = useGetMatchSchedule(matchType);
+  const { data: matchSchedule, isLoading } = useGetMatchSchedule(matchType);
+
+  if (isLoading) {
+    return <MatchDetailSkeleton matchType={matchType} />;
+  }
 
   return (
     <div className="flex justify-start w-full max-w-[1200px] items-center mx-auto gap-x-[40px]">

--- a/src/app/(route)/matchBroadcast/_components/MatchPrediction.tsx
+++ b/src/app/(route)/matchBroadcast/_components/MatchPrediction.tsx
@@ -28,6 +28,9 @@ const MatchPrediction = ({ matchId, scheduleData }: MatchPredictionProps) => {
   const isStart = startTime ? now >= startTime : false;
 
   const isVoted = matchData?.data?.vote === true;
+  const voteHome = matchData?.data?.side === "HOME";
+  const voteAway = matchData?.data?.side === "AWAY";
+  console.log(voteHome, "voteHome");
 
   const isLoggedIn = () => {
     const token = localStorage.getItem("accessToken");
@@ -100,14 +103,20 @@ const MatchPrediction = ({ matchId, scheduleData }: MatchPredictionProps) => {
       >
         {isVoted && (
           <div className="absolute inset-0 flex w-full h-full">
-            <div className="h-full bg-gray8 w-1/2"></div>
-            <div className="h-full bg-gray6 w-1/2"></div>
+            <div
+              className={`h-full ${voteHome ? "bg-gray8" : "bg-gray6"}`}
+              style={{ width: `${matchData?.data?.home}%` }}
+            ></div>
+            <div
+              className={`h-full ${voteAway ? "bg-gray8" : "bg-gray6"}`}
+              style={{ width: `${matchData?.data?.away}%` }}
+            ></div>
           </div>
         )}
         <div
           className={`flex justify-between items-center text-white w-full min-h-[54px] relative z-10 font-[700] text-[24px] leading-[38px] ${
-            !isVoted ? "bg-gray3" : ""
-          }`}
+            isVoted ? "pointer-events-none" : ""
+          } ${!isVoted ? "bg-gray3" : ""}`}
         >
           <div
             onClick={() => handleVote("HOME")}

--- a/src/app/(route)/matchBroadcast/_components/MatchPrediction.tsx
+++ b/src/app/(route)/matchBroadcast/_components/MatchPrediction.tsx
@@ -21,8 +21,6 @@ const MatchPrediction = ({ matchId, scheduleData }: MatchPredictionProps) => {
   const { data: matchData } = useGetMatchPrediction(matchId);
   const votePrediction = usePatchMatchPrediction();
 
-  console.log(matchData, "matchData");
-
   const now = new Date();
   const startTime = new Date(matchData?.data?.startTime);
   const isStart = startTime ? now >= startTime : false;
@@ -30,7 +28,6 @@ const MatchPrediction = ({ matchId, scheduleData }: MatchPredictionProps) => {
   const isVoted = matchData?.data?.vote === true;
   const voteHome = matchData?.data?.side === "HOME";
   const voteAway = matchData?.data?.side === "AWAY";
-  console.log(voteHome, "voteHome");
 
   const isLoggedIn = () => {
     const token = localStorage.getItem("accessToken");

--- a/src/app/(route)/matchBroadcast/_components/matchSkeleton.tsx
+++ b/src/app/(route)/matchBroadcast/_components/matchSkeleton.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from "@heroui/react";
+
+interface MatchSkeletonProps {
+  matchType: string;
+}
+
+const MatchDetailSkeleton = ({ matchType }: MatchSkeletonProps) => {
+  const isEsports = matchType === "ESPORTS";
+  return (
+    <div className="flex justify-start w-full max-w-[1200px] items-center mx-auto gap-x-[40px]">
+      <div className="flex flex-col w-[800px] gap-y-[20px]">
+        {/* 라이브 섹션 스켈레톤 */}
+        {isEsports && (
+          <div className="w-full h-[440px] bg-gray1 rounded-lg flex justify-center items-center">
+            <Skeleton className="w-full h-full rounded-lg" />
+          </div>
+        )}
+        {/* 예측 섹션 헤더 스켈레톤 */}
+        {/* 예측 섹션 스켈레톤 */}
+        <div className="w-full space-y-[12px]">
+          <Skeleton className="w-[200px] h-[28px] rounded-md" />
+          <Skeleton className="w-full h-[100px] rounded-lg" />
+          <div className="flex gap-4">
+            <Skeleton className="flex-1 h-[48px] rounded-md" />
+            <Skeleton className="flex-1 h-[48px] rounded-md" />
+          </div>
+        </div>
+      </div>
+      {/* <div className="w-[360px]">채팅 구역</div> */}
+    </div>
+  );
+};
+
+export default MatchDetailSkeleton;

--- a/src/app/_components/EsportsSchedule.tsx
+++ b/src/app/_components/EsportsSchedule.tsx
@@ -21,7 +21,6 @@ const EsportsSchedule = ({ onMatchClick }: EsportsScheduleProps) => {
     pathname.startsWith("/matchBroadcast/ESPORTS");
 
   const { data: esportsSchedule, isLoading } = useGetEsportsSchedule();
-  console.log(esportsSchedule, "esportsSchedule");
   const [currentPage, setCurrentPage] = useState(0);
   const [isSelected, setIsSelected] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<number | null>(null);

--- a/src/services/match-controller/getMatchPredition.ts
+++ b/src/services/match-controller/getMatchPredition.ts
@@ -16,6 +16,7 @@ interface PredictionData {
   matchId: number;
   startTime: string;
   vote: boolean;
+  side: string;
 }
 
 interface PredictionResponse {


### PR DESCRIPTION
## 변경 사항 요약

-  승부예측 투표한 곳에 bg-gray8 안 한 곳엔 bg-gray6으로 수정
-  승부예측 퍼센트에 따라 width : % 로 수정
-  경기일정 페이지 댓글 구현 ( response 값 백엔드에 요청 완료 )

### 추가된 기능

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [x] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

<!-- 리뷰어가 주목해야 할 부분이나 추가적인 정보가 있다면 기재해주세요. -->

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
