### PR TITLE
오른쪽 사이드바 뉴스 width 값 및 썸네일 수정

### DIFF
--- a/src/app/(route)/(community)/_components/RightNewsItem.tsx
+++ b/src/app/(route)/(community)/_components/RightNewsItem.tsx
@@ -11,9 +11,14 @@ import { cn } from "@/utils";
 interface NewsItemProps {
   newsItem: NewsItemType;
   customClass?: string;
+  wrapperWidth?: number;
 }
 
-const RightNewsItem = ({ newsItem, customClass }: NewsItemProps) => {
+const RightNewsItem = ({
+  newsItem,
+  customClass,
+  wrapperWidth,
+}: NewsItemProps) => {
   const { handleRead } = useReadNews(newsItem?.id, false);
   const [read, setRead] = useState(false);
   const pathname = usePathname();
@@ -27,10 +32,16 @@ const RightNewsItem = ({ newsItem, customClass }: NewsItemProps) => {
     setRead(isReadInStorage || isCurrentPage);
   }, [newsItem?.id, pathname]);
 
-  const titleStyle =
-    "w-[194px] h-[24px] font-[700] text-[16px] leading-6 tracking-[-0.02em] text-ellipsis overflow-hidden whitespace-nowrap mobile:w-full";
-  const contentStyle =
-    "w-[194px] h-[40px] text-[14px] leading-5 tracking-[0%] opacity-90 line-clamp-2 overflow-hidden mobile:w-full";
+  const isWide = wrapperWidth === 298;
+
+  const titleStyle = cn(
+    isWide ? "w-[194px]" : "w-[184px]",
+    "h-[24px] font-[700] text-[16px] leading-6 tracking-[-0.02em] text-ellipsis overflow-hidden whitespace-nowrap mobile:w-full"
+  );
+  const contentStyle = cn(
+    isWide ? "w-[194px]" : "w-[184px]",
+    "h-[40px] text-[14px] leading-5 tracking-[0%] opacity-90 line-clamp-2 overflow-hidden mobile:w-full"
+  );
 
   const styles = {
     title: `${titleStyle} ${read ? "text-gray5" : "text-gray9"}`,

--- a/src/app/(route)/(community)/_components/RightSideBar.tsx
+++ b/src/app/(route)/(community)/_components/RightSideBar.tsx
@@ -79,6 +79,7 @@ export const RightSideBar = () => {
                 <RightNewsItem
                   key={data.id}
                   newsItem={data}
+                  wrapperWidth={288}
                   customClass="w-full h-[92px] rounded-[5px] bg-white p-3 box-border"
                 />
               ))}

--- a/src/app/(route)/main/HomePage.tsx
+++ b/src/app/(route)/main/HomePage.tsx
@@ -10,10 +10,12 @@ import useGetNewsDataList from "@/_hooks/fetcher/news/useGetNewsDataList";
 import useAuthCheck from "@/_hooks/useAuthCheck";
 import { cn } from "@/utils";
 import MainLivePost from "./_components/MainLivePost";
+import useIsTablet from "@/utils/useIsTablet";
 
 function HomePageContent() {
   const refreshToken = useHandleRefreshToken();
   const { data: userData } = useAuthCheck();
+  const isTablet = useIsTablet();
 
   const {
     data: newsData,
@@ -86,9 +88,11 @@ function HomePageContent() {
                     data={newsItems}
                     isLoading={newsDataIsLoading}
                   />
-                  <div className={cn("hidden", "tablet:block")}>
-                    <MainRightBar />
-                  </div>
+                  {isTablet && (
+                    <div className="tablet:block">
+                      <MainRightBar />
+                    </div>
+                  )}
                 </div>
               )}
               <div className={cn("w-full", "tablet:w-full")}>
@@ -96,15 +100,16 @@ function HomePageContent() {
               </div>
             </div>
           </div>
-          <div
-            className={cn(
-              "max-w-[298px] min-h-[696px] flex-1",
-              "tablet:hidden",
-              "mobile:max-w-full mobile:min-h-fit"
-            )}
-          >
-            <MainRightBar />
-          </div>
+          {!isTablet && (
+            <div
+              className={cn(
+                "max-w-[298px] min-h-[696px] flex-1",
+                "mobile:max-w-full mobile:min-h-fit"
+              )}
+            >
+              <MainRightBar />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/(route)/main/_components/MainRightBar.tsx
+++ b/src/app/(route)/main/_components/MainRightBar.tsx
@@ -124,6 +124,7 @@ const MainRightBar = () => {
                 <RightNewsItem
                   key={data.id}
                   newsItem={data}
+                  wrapperWidth={298}
                   customClass={cn(
                     "max-w-[298px] h-[92px] border rounded-[5px] border-gray2 bg-white p-3",
                     "mobile:max-w-full"


### PR DESCRIPTION
## 변경 사항 요약

 썸네일 이미지가 tablet 구간에서 block/hidden 스타일 사용으로 DOM이 2개 렌더링되어 굵어지는 현상 발생 
 -조건문으로 반응형 분기 처리

-사이드바 뉴스 width 값 분기 처리

### 추가된 기능

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [ ] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

<!-- 리뷰어가 주목해야 할 부분이나 추가적인 정보가 있다면 기재해주세요. -->

### PR 올리기 전 체크리스트 (필수로 체크)

- [ ] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [ ] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
