### PR TITLE
에디터 플레이스 홀더 벗어나는 버그, 모바일 이미지 최소값 변경

### DIFF
--- a/src/app/_components/_tiptap/Tiptap.tsx
+++ b/src/app/_components/_tiptap/Tiptap.tsx
@@ -132,8 +132,7 @@ const Tiptap = ({
       Link,
       CustomImage.configure({
         HTMLAttributes: {
-          class:
-            "w-full h-auto mx-auto block mobile:max-w-[200px] mobile:max-h-[200px]",
+          class: "w-full h-auto mx-auto block mobile:w-auto mobile:h-auto",
         },
         allowBase64: true,
         inline: false,
@@ -152,7 +151,7 @@ const Tiptap = ({
     editorProps: {
       attributes: {
         class:
-          "editor-class flex flex-col font-medium text-[14px] leading-[20px] text-gray7 min-h-[375px] p-4 gap-y-[2px]",
+          "editor-class flex flex-col font-medium text-[14px] leading-[20px] text-gray7 min-h-[430px] tablet:min-h-[430px] mobile:min-h-[530px] p-4 gap-y-[2px]",
       },
       handlePaste: (view, event) => {
         const items = Array.from(event.clipboardData?.items || []);


### PR DESCRIPTION
## 변경 사항 요약
모바일 , 테블릿, PC 에디터 플레이스 홀더 최소값 변경 ( 스크롤은 유지 )
모바일에서 이미지 삽입시 최대 크기 지정 해제

### 추가된 기능

- [ ] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [ ] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

<!-- 리뷰어가 주목해야 할 부분이나 추가적인 정보가 있다면 기재해주세요. -->

### PR 올리기 전 체크리스트 (필수로 체크)

- [ ] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [ ] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
