### PR TITLE
뉴스 오른쪽 컴포넌트 수정

### DIFF
--- a/src/app/(route)/(community)/_components/RightSideBar.tsx
+++ b/src/app/(route)/(community)/_components/RightSideBar.tsx
@@ -17,6 +17,7 @@ export const RightSideBar = () => {
   const [content, setContent] = useState<NewsItemType[]>([]);
   const [isPaginating, setIsPaginating] = useState(false);
   const [isTopVisible, setIsTopVisible] = useState(false);
+  const [hasData, setHasData] = useState<boolean>(false);
 
   const sidebarRef = useRef<HTMLElement | null>(null);
 
@@ -40,6 +41,9 @@ export const RightSideBar = () => {
       setContent(newsData.content);
       setTotalPage(newsData?.pageInfo?.totalPage);
       setIsPaginating(false);
+      setHasData(newsData.content && newsData.content.length > 0);
+    } else if (!isLoading && !newsData) {
+      setHasData(false);
     }
   }, [newsData]);
 
@@ -92,73 +96,75 @@ export const RightSideBar = () => {
     }
   };
 
+  if (!hasData && !isLoading) {
+    return null;
+  }
+
   return (
-    newsData && (
-      <aside
-        ref={sidebarRef}
-        className={cn(
-          "w-[288px] h-auto max-h-[880px] top-[250px] left-[1272px] flex flex-col gap-[24px]",
-          !isLoading && content.length === 0 ? "hidden" : ""
-        )}
-        aria-label="뉴스 오른쪽 사이드 바"
+    <aside
+      ref={sidebarRef}
+      className={cn(
+        "w-[288px] h-auto max-h-[880px] top-[250px] left-[1272px] flex flex-col gap-[24px]",
+        !isLoading && content.length === 0 ? "hidden" : ""
+      )}
+      aria-label="뉴스 오른쪽 사이드 바"
+    >
+      <section
+        className="w-full h-auto max-h-[808px] flex flex-col gap-4 pb-6 shadow-md rounded-[10px] bg-white"
+        aria-label="오른쪽 사이드 바 뉴스 목록"
       >
-        <section
-          className="w-full h-auto max-h-[808px] flex flex-col gap-4 pb-6 shadow-md rounded-[10px] bg-white"
-          aria-label="오른쪽 사이드 바 뉴스 목록"
-        >
-          <div className="w-full h-auto max-h-[736px] rounded-[10px]">
-            {content.length === 0 && isLoading && !isPaginating
-              ? Array.from({ length: 5 }).map((_, index) => (
-                  <RightNewsItemSkeleton key={index} />
-                ))
-              : content?.map((data: NewsItemType) => (
-                  <RightNewsItem
-                    key={data.id}
-                    newsItem={data}
-                    wrapperWidth={288}
-                    customClass="w-full h-[92px] rounded-[5px] bg-white p-3 box-border"
-                  />
-                ))}
-          </div>
+        <div className="w-full h-auto max-h-[736px] rounded-[10px]">
+          {content.length === 0 && isLoading && !isPaginating
+            ? Array.from({ length: 5 }).map((_, index) => (
+                <RightNewsItemSkeleton key={index} />
+              ))
+            : content?.map((data: NewsItemType) => (
+                <RightNewsItem
+                  key={data.id}
+                  newsItem={data}
+                  wrapperWidth={288}
+                  customClass="w-full h-[92px] rounded-[5px] bg-white p-3 box-border"
+                />
+              ))}
+        </div>
 
-          {(isLoading || (totalPage ?? 0) > 1) && (
-            <nav
-              className="w-[160px] h-[32px] flex gap-4 items-center justify-center m-auto"
-              aria-label="오른쪽 뉴스 목록 페이지네이션"
-            >
-              <button
-                onClick={() => handleToPage("prev")}
-                className={getNavButtonClass(Number(currentPage) === 1)}
-                aria-label="이전 페이지로 이동"
-              >
-                <Arrow_left width={18} height={18} />
-              </button>
-              <div className="w-[64px] h-[32px] font-[500] text-[14px] leading-[20px] text-gray6 flex items-center justify-center">
-                {currentPage} / {totalPage}
-              </div>
-              <button
-                onClick={() => handleToPage("next")}
-                className={getNavButtonClass(
-                  Number(currentPage) === Number(totalPage)
-                )}
-                aria-label="다음 페이지로 이동"
-              >
-                <Arrow_right width={18} height={18} />
-              </button>
-            </nav>
-          )}
-        </section>
-
-        {isTopVisible && (
-          <button
-            onClick={scrollToTop}
-            className="w-[48px] h-[48px] bg-white rounded-[10px] shadow-md flex justify-center items-center p-[10px] gap-[10px] cursor-pointer"
-            aria-label="상단으로 이동 버튼"
+        {(isLoading || (totalPage ?? 0) > 1) && (
+          <nav
+            className="w-[160px] h-[32px] flex gap-4 items-center justify-center m-auto"
+            aria-label="오른쪽 뉴스 목록 페이지네이션"
           >
-            <Arrow_up />
-          </button>
+            <button
+              onClick={() => handleToPage("prev")}
+              className={getNavButtonClass(Number(currentPage) === 1)}
+              aria-label="이전 페이지로 이동"
+            >
+              <Arrow_left width={18} height={18} />
+            </button>
+            <div className="w-[64px] h-[32px] font-[500] text-[14px] leading-[20px] text-gray6 flex items-center justify-center">
+              {currentPage} / {totalPage}
+            </div>
+            <button
+              onClick={() => handleToPage("next")}
+              className={getNavButtonClass(
+                Number(currentPage) === Number(totalPage)
+              )}
+              aria-label="다음 페이지로 이동"
+            >
+              <Arrow_right width={18} height={18} />
+            </button>
+          </nav>
         )}
-      </aside>
-    )
+      </section>
+
+      {isTopVisible && (
+        <button
+          onClick={scrollToTop}
+          className="w-[48px] h-[48px] bg-white rounded-[10px] shadow-md flex justify-center items-center p-[10px] gap-[10px] cursor-pointer"
+          aria-label="상단으로 이동 버튼"
+        >
+          <Arrow_up />
+        </button>
+      )}
+    </aside>
   );
 };


### PR DESCRIPTION
## 변경 사항 요약

- 메인 페이지를 제외한 오른쪽 뉴스의 페이지네이션을 클릭하면 컴포넌트가 깜빡이는 문제가 있어서 기존 로직을 수정했습니다.

### 추가된 기능

- [x] 버그 수정
- [ ] 코드 스타일 개선 (포맷팅, 변수명 변경 등)
- [ ] 리팩토링 (기능 변경 없이 코드 개선)
- [ ] UI 변경
- [ ] 성능 개선
- [ ] 기타 (설명해주세요):

### 리뷰어를 위한 참고 사항

newsData가 true일때 return 해주는 방식을 사용했었는데, 이렇게 진행하면 페이지네이션 기능을 사용했을때 뉴스 데이터가
페이지네이션 클릭 -> 데이터 요청 -> 컴포넌트 사라짐(요청중엔 데이터가 없음) -> 데이터 정상 도착(데이터가 생기며 렌더링) -> 깜빡임 발생
으로 인해 발생하는 문제여서 기존 로직을 삭제하고, state 로 관리하는 방식으로 추가했습니다.

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인
